### PR TITLE
feat: Initialize SignIn page with styled components and form inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="src/assets/logo.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Oswald:wght@200..700&family=Passion+One:wght@400;700;900&family=Recursive:wght@600&display=swap" rel="stylesheet">
     <title>Linkr</title>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "linkr-front",
       "version": "0.0.0",
       "dependencies": {
+        "animate.css": "^4.1.1",
         "axios": "^1.6.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1266,6 +1267,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/animate.css": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-4.1.1.tgz",
+      "integrity": "sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ=="
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "animate.css": "^4.1.1",
     "axios": "^1.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom"
 
-import { UserProvider } from './contexts/UserContext'
+import UserProvider from './contexts/UserContext';
 import HomePage from "./pages/HomePage"
 import SignInPage from "./pages/SignInPage"
 import SignUpPage from "./pages/SignUpPage"

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <div>
+      <h1>Welcome to the Home Page</h1>
+    </div>
+  );
+}
+

--- a/src/pages/SignInPage.jsx
+++ b/src/pages/SignInPage.jsx
@@ -1,0 +1,136 @@
+import axios from "axios";
+import styled, { keyframes } from "styled-components";
+import 'animate.css';
+
+import { Link, useNavigate } from "react-router-dom";
+import { useState, useContext } from "react";
+
+import { UserContext } from '/src/contexts/UserContext';
+
+export default function SignInPage() {
+  const { setUser } = useContext(UserContext);
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  function handleSignIn() {
+
+  }
+
+  return (
+    <SignInContainer>
+      <SignInContainerLeft>
+        <h1>linkr</h1>
+        <h2>save, share and discover the best links on the web</h2>
+      </SignInContainerLeft>
+      <SignInContainerRight>
+
+      <FormContainer onSubmit={handleSignIn}>
+        <input 
+          type="email" 
+          placeholder="E-mail" 
+          value={email} 
+          required 
+          onChange={e => setEmail(e.target.value)}>
+        </input>
+        <input 
+          type="password" 
+          placeholder="Password" 
+          value={password}
+          required 
+          onChange={e => setPassword(e.target.value)}>
+        </input>
+        <button>Sign In</button>
+      </FormContainer>
+
+      <Link to={'/signUp'}>First time? Create an account!</Link>
+      </SignInContainerRight>
+    </SignInContainer>
+  );
+}
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+
+const SignInContainer = styled.div`
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+`;
+
+const SignInContainerLeft = styled.div`
+  width: 60%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  user-select: none;
+
+  background-color:#151515;
+  color: #FFF;
+  h1{
+    animation: ${fadeIn} 1s ease-out;
+    margin-left: 15%;
+    font-family: Passion One;
+    font-size : min(14vh, 14vw);
+    letter-spacing: 5px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: normal;
+  }
+  h2{
+    animation: ${fadeIn} 1s ease-out;
+    width: 60%;
+    margin-left: 15%;
+    font-family: Oswald;
+    font-size : min(6vh, 6vw);
+    font-style: normal;
+    font-weight: 700;
+    line-height: normal;
+  }
+`;
+
+const SignInContainerRight = styled.div`
+  width: 40%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+
+const FormContainer = styled.form`
+  width: 80%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  input{
+    width: 100%;
+    height: 65px;
+    border: none; 
+    border-radius: 6px;
+    color: #9F9F9F;
+
+    font-family: Oswald;
+    font-size: 27px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: normal;
+  }
+  button{
+
+  }
+`;

--- a/src/pages/SignUpPage.jsx
+++ b/src/pages/SignUpPage.jsx
@@ -1,0 +1,7 @@
+export default function SignUpPage() {
+  return (
+    <div>
+      <h1>Welcome to the Sing-Up Page</h1>
+    </div>
+  );
+}

--- a/src/styles/GlobalStyle.jsx
+++ b/src/styles/GlobalStyle.jsx
@@ -1,5 +1,9 @@
 import { createGlobalStyle } from "styled-components";
 
-const GlobalStyle = createGlobalStyle``;
+const GlobalStyle = createGlobalStyle`
+  body{
+    background-color:#333;
+  }
+`;
 
 export default GlobalStyle;


### PR DESCRIPTION
This commit introduces the SignIn page, incorporating styled components for layout and design. Key features include input fields for email and password, and setup for sign-in functionality. The page layout is divided into left and right containers with animations and styled form elements, enhancing the user interface. Further integration with sign-in logic and user context is prepared but not yet implemented.